### PR TITLE
Feat/#26 alert screen구현

### DIFF
--- a/core/datastore/src/main/java/com/umcspot/spot/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/java/com/umcspot/spot/datastore/di/DataStoreModule.kt
@@ -4,6 +4,10 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.dataStoreFile
+import com.umcspot.spot.datastore.token.SpotSecureDataStoreSerializer
+import com.umcspot.spot.datastore.token.SpotTokenData
+import com.umcspot.spot.datastore.userId.SpotUserIdData
+import com.umcspot.spot.datastore.userId.SpotUserIdDataStoreSerializer
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -24,6 +28,18 @@ object DataStoreModule {
         return DataStoreFactory.create(
             serializer = serializer,
             produceFile = { context.dataStoreFile("spot_tokens.secure") }
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideSpotUserIdDataStore(
+        @ApplicationContext context: Context,
+        serializer: SpotUserIdDataStoreSerializer
+    ): DataStore<SpotUserIdData> {
+        return DataStoreFactory.create(
+            serializer = serializer,
+            produceFile = { context.dataStoreFile("spot_userId.secure") }
         )
     }
 }

--- a/core/datastore/src/main/java/com/umcspot/spot/datastore/token/SpotSecureDataStoreSerializer.kt
+++ b/core/datastore/src/main/java/com/umcspot/spot/datastore/token/SpotSecureDataStoreSerializer.kt
@@ -1,0 +1,100 @@
+package com.umcspot.spot.datastore.token
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import androidx.datastore.core.Serializer
+import kotlinx.serialization.json.Json
+import java.io.InputStream
+import java.io.OutputStream
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.inject.Inject
+
+class SpotSecureDataStoreSerializer @Inject constructor() : Serializer<SpotTokenData> {
+    companion object {
+        private const val KEYSTORE_PROVIDER = "AndroidKeyStore"
+        private const val KEY_ALIAS = "data-store-key"
+        private const val TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val IV_SIZE = 12
+    }
+
+    private val keyStore: KeyStore by lazy {
+        KeyStore.getInstance(KEYSTORE_PROVIDER).apply {
+            load(null)
+            if (!containsAlias(KEY_ALIAS)) {
+                createKey()
+            }
+        }
+    }
+
+    private fun createKey() {
+        val keyGenerator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            KEYSTORE_PROVIDER
+        )
+        val keyGenParameterSpec = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(256)
+            .build()
+
+        keyGenerator.init(keyGenParameterSpec)
+        keyGenerator.generateKey()
+    }
+
+    override val defaultValue: SpotTokenData
+        get() = SpotTokenData()
+
+    override suspend fun readFrom(input: InputStream): SpotTokenData {
+        return try {
+            val encryptedDataWithIv = input.readBytes()
+            if (encryptedDataWithIv.size < IV_SIZE) {
+                return defaultValue
+            }
+
+            val iv = encryptedDataWithIv.copyOfRange(0, IV_SIZE)
+            val encryptedData = encryptedDataWithIv.copyOfRange(IV_SIZE, encryptedDataWithIv.size)
+
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            val key = keyStore.getKey(KEY_ALIAS, null) as SecretKey
+            val spec = GCMParameterSpec(128, iv)
+            cipher.init(Cipher.DECRYPT_MODE, key, spec)
+
+            val decryptedBytes = cipher.doFinal(encryptedData)
+            Json.decodeFromString(
+                deserializer = SpotTokenData.serializer(),
+                string = decryptedBytes.decodeToString()
+            )
+        } catch (e: Exception) {
+            e.printStackTrace()
+            defaultValue
+        }
+    }
+
+    override suspend fun writeTo(t: SpotTokenData, output: OutputStream) {
+        try {
+            val serializedData = Json.encodeToString(
+                serializer = SpotTokenData.serializer(),
+                value = t
+            )
+
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            val key = keyStore.getKey(KEY_ALIAS, null) as SecretKey
+            cipher.init(Cipher.ENCRYPT_MODE, key)
+
+            val iv = cipher.iv
+            val encryptedData = cipher.doFinal(serializedData.toByteArray())
+
+            output.write(iv + encryptedData)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            throw e
+        }
+    }
+}

--- a/core/datastore/src/main/java/com/umcspot/spot/datastore/token/SpotTokenData.kt
+++ b/core/datastore/src/main/java/com/umcspot/spot/datastore/token/SpotTokenData.kt
@@ -1,6 +1,8 @@
-@file:OptIn(kotlinx.serialization.InternalSerializationApi::class)
-package com.umcspot.spot.datastore
+@file:OptIn(InternalSerializationApi::class)
 
+package com.umcspot.spot.datastore.token
+
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/core/datastore/src/main/java/com/umcspot/spot/datastore/userId/SpotUserIdData.kt
+++ b/core/datastore/src/main/java/com/umcspot/spot/datastore/userId/SpotUserIdData.kt
@@ -1,0 +1,11 @@
+@file:OptIn(InternalSerializationApi::class)
+
+package com.umcspot.spot.datastore.userId
+
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SpotUserIdData(
+    val userId: String = "",
+)

--- a/core/datastore/src/main/java/com/umcspot/spot/datastore/userId/SpotUserIdDataStoreSerializer.kt
+++ b/core/datastore/src/main/java/com/umcspot/spot/datastore/userId/SpotUserIdDataStoreSerializer.kt
@@ -1,4 +1,4 @@
-package com.umcspot.spot.datastore
+package com.umcspot.spot.datastore.userId
 
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
@@ -13,7 +13,7 @@ import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
 import javax.inject.Inject
 
-class SpotSecureDataStoreSerializer @Inject constructor() : Serializer<SpotTokenData> {
+class SpotUserIdDataStoreSerializer @Inject constructor() : Serializer<SpotUserIdData> {
     companion object {
         private const val KEYSTORE_PROVIDER = "AndroidKeyStore"
         private const val KEY_ALIAS = "data-store-key"
@@ -48,10 +48,10 @@ class SpotSecureDataStoreSerializer @Inject constructor() : Serializer<SpotToken
         keyGenerator.generateKey()
     }
 
-    override val defaultValue: SpotTokenData
-        get() = SpotTokenData()
+    override val defaultValue: SpotUserIdData
+        get() = SpotUserIdData()
 
-    override suspend fun readFrom(input: InputStream): SpotTokenData {
+    override suspend fun readFrom(input: InputStream): SpotUserIdData {
         return try {
             val encryptedDataWithIv = input.readBytes()
             if (encryptedDataWithIv.size < IV_SIZE) {
@@ -68,7 +68,7 @@ class SpotSecureDataStoreSerializer @Inject constructor() : Serializer<SpotToken
 
             val decryptedBytes = cipher.doFinal(encryptedData)
             Json.decodeFromString(
-                deserializer = SpotTokenData.serializer(),
+                deserializer = SpotUserIdData.serializer(),
                 string = decryptedBytes.decodeToString()
             )
         } catch (e: Exception) {
@@ -77,10 +77,10 @@ class SpotSecureDataStoreSerializer @Inject constructor() : Serializer<SpotToken
         }
     }
 
-    override suspend fun writeTo(t: SpotTokenData, output: OutputStream) {
+    override suspend fun writeTo(t: SpotUserIdData, output: OutputStream) {
         try {
             val serializedData = Json.encodeToString(
-                serializer = SpotTokenData.serializer(),
+                serializer = SpotUserIdData.serializer(),
                 value = t
             )
 

--- a/core/designsystem/src/main/java/com/umcspot/spot/designsystem/component/study/StudyItem.kt
+++ b/core/designsystem/src/main/java/com/umcspot/spot/designsystem/component/study/StudyItem.kt
@@ -2,7 +2,9 @@ package com.umcspot.spot.designsystem.component.study
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -26,6 +29,8 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.umcspot.spot.designsystem.R
 import com.umcspot.spot.designsystem.component.button.ClickSurface
+import com.umcspot.spot.designsystem.component.button.TextButton
+import com.umcspot.spot.designsystem.component.button.TextButtonState
 import com.umcspot.spot.designsystem.shapes.SpotShapes
 import com.umcspot.spot.designsystem.theme.SpotTheme
 import com.umcspot.spot.model.ImageRef
@@ -65,7 +70,10 @@ fun StudyListItem(
                     .padding(screenHeightDp(4.dp))
             ) {
                 Row{
-                    Column{
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                    ) {
                         Text(
                             text = item.name,
                             style = SpotTheme.typography.h5,
@@ -80,9 +88,11 @@ fun StudyListItem(
                         )
                     }
                     if (checkAppliedSlot != null) {
-                        Spacer(modifier = Modifier.weight(1f))
-
                         checkAppliedSlot()
+                    }
+
+                    if(meetballSlot != null) {
+                        meetballSlot()
                     }
                 }
 
@@ -101,11 +111,6 @@ fun StudyListItem(
                         iconRes = R.drawable.like_default, count2 = item.likeCount
                     )
                 }
-            }
-            Spacer(modifier = Modifier.weight(1f))
-
-            if (meetballSlot != null) {
-                meetballSlot()
             }
         }
     }
@@ -199,7 +204,7 @@ private fun StudyListItemPreview() {
             item = StudyResult(
                 id = 1,
                 name = "Sample Study",
-                description = "Sample Goal",
+                description = "Sample GoalSample GoalSample GoalSample GoalSample GoalSample Goal",
                 maxMembers = 10,
                 currentMembers = 5,
                 likeCount = 400,
@@ -211,6 +216,36 @@ private fun StudyListItemPreview() {
             ),
             modifier = Modifier.padding(10.dp),
             onClick = {},
+            checkAppliedSlot = {
+                TextButton(
+                    modifier = Modifier
+                        .width(screenWidthDp(60.dp))
+                        .height(screenHeightDp(26.dp)),
+                    text = "신청 확인",
+                    style = SpotTheme.typography.regular_500,
+                    onClick = {},
+                    state = TextButtonState.B500State,
+                    shape = SpotShapes.Hard
+                )
+            }
+//            meetballSlot = {
+//                Box {
+//                    Box(
+//                        modifier = Modifier
+//                            .padding(top = screenHeightDp(4.dp))
+//                            .width(screenWidthDp(24.dp))
+//                            .height(screenWidthDp(22.dp))
+//                            .clip(SpotShapes.Hard),
+//                        contentAlignment = Alignment.Center
+//                    ) {
+//                        Icon(
+//                            painter = painterResource(R.drawable.meetball),
+//                            contentDescription = null,
+//                            modifier = Modifier.size(screenWidthDp(14.dp))
+//                        )
+//                    }
+//                }
+//            }
         )
     }
 }

--- a/core/designsystem/src/main/java/com/umcspot/spot/designsystem/shapes/Shapes.kt
+++ b/core/designsystem/src/main/java/com/umcspot/spot/designsystem/shapes/Shapes.kt
@@ -84,6 +84,7 @@ fun ShapeImageWithBadge(
     borderColor: Color? = Color.Transparent,
     contentScale: ContentScale = ContentScale.Fit,
     badgeSize: Dp = 16.dp,
+    backgroundColor: Color = SpotTheme.colors.white
 ) {
     Box(
         modifier = modifier.size(screenWidthDp(size)),
@@ -96,7 +97,8 @@ fun ShapeImageWithBadge(
             borderWidth = borderWidth,
             padding = padding,
             borderColor = borderColor,
-            contentScale = contentScale
+            contentScale = contentScale,
+            backgroundColor = backgroundColor
         )
 
         Icon(

--- a/core/network/src/main/java/com/umcspot/spot/network/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/umcspot/spot/network/AuthInterceptor.kt
@@ -1,7 +1,7 @@
 package com.umcspot.spot.network
 
 import androidx.datastore.core.DataStore
-import com.umcspot.spot.datastore.SpotTokenData
+import com.umcspot.spot.datastore.token.SpotTokenData
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor

--- a/data/alert/src/main/java/com/umcspot/spot/alert/datasource/AlertDataSource.kt
+++ b/data/alert/src/main/java/com/umcspot/spot/alert/datasource/AlertDataSource.kt
@@ -1,9 +1,15 @@
 package com.umcspot.spot.alert.datasource
 
 import com.umcspot.spot.alert.dto.response.AlertResponseDto
+import com.umcspot.spot.alert.dto.response.UnReadAlertResponseDto
 import com.umcspot.spot.network.model.BaseResponse
+import com.umcspot.spot.network.model.NullResultResponse
 
 interface AlertDataSource {
     suspend fun getAlerts(): BaseResponse<AlertResponseDto>
+
+    suspend fun getUnReadAlerts(): BaseResponse<UnReadAlertResponseDto>
+
+    suspend fun readAlert(notificationId : Long): NullResultResponse
 
 }

--- a/data/alert/src/main/java/com/umcspot/spot/alert/datasourceimpl/AlertDataSourceImpl.kt
+++ b/data/alert/src/main/java/com/umcspot/spot/alert/datasourceimpl/AlertDataSourceImpl.kt
@@ -2,8 +2,10 @@ package com.umcspot.spot.alert.datasourceimpl
 
 import com.umcspot.spot.alert.datasource.AlertDataSource
 import com.umcspot.spot.alert.dto.response.AlertResponseDto
+import com.umcspot.spot.alert.dto.response.UnReadAlertResponseDto
 import com.umcspot.spot.alert.service.AlertService
 import com.umcspot.spot.network.model.BaseResponse
+import com.umcspot.spot.network.model.NullResultResponse
 import javax.inject.Inject
 
 class AlertDataSourceImpl @Inject constructor(
@@ -12,4 +14,10 @@ class AlertDataSourceImpl @Inject constructor(
     override suspend fun getAlerts(
     ): BaseResponse<AlertResponseDto> =
         alertService.getAlerts()
+
+    override suspend fun getUnReadAlerts(): BaseResponse<UnReadAlertResponseDto> =
+        alertService.getUnReadAlerts()
+
+    override suspend fun readAlert(notificationId: Long): NullResultResponse =
+        alertService.readAlert(notificationId)
 }

--- a/data/alert/src/main/java/com/umcspot/spot/alert/dto/response/AlertResponseDto.kt
+++ b/data/alert/src/main/java/com/umcspot/spot/alert/dto/response/AlertResponseDto.kt
@@ -1,29 +1,46 @@
 package com.umcspot.spot.alert.dto.response
 
 import android.annotation.SuppressLint
-import com.umcspot.spot.model.ImageRef
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @SuppressLint("UnsafeOptInUsageError")
 @Serializable
 data class AlertResponseDto(
-    @SerialName("studies")
-    val studies : List<AlertItem>
+    @SerialName("notifications")
+    val notifications : List<AlertItem>,
+
+    @SerialName("totalCount")
+    val totalCount: Int
 )
 
 @SuppressLint("UnsafeOptInUsageError")
 @Serializable
 data class AlertItem(
-    @SerialName("applicationId")
-    val applicationId: String,
+    @SerialName("notificationId")
+    val notificationId: String,
 
-    @SerialName("studyId")
-    val studyId: String,
+    @SerialName("type")
+    val type: String,
 
     @SerialName("title")
     val title: String,
 
-    @SerialName("profileImageRef")
-    val profileImageRef: ImageRef,
+    @SerialName("body")
+    val body: String,
+
+    @SerialName("imageUrl")
+    val imageUrl: String?,
+
+    @SerialName("referenceType")
+    val referenceType: String,
+
+    @SerialName("referenceId")
+    val referenceId: String,
+
+    @SerialName("isRead")
+    val isRead: Boolean,
+
+    @SerialName("createdAt")
+    val createdAt: String,
 )

--- a/data/alert/src/main/java/com/umcspot/spot/alert/dto/response/UnReadAlertResponseDto.kt
+++ b/data/alert/src/main/java/com/umcspot/spot/alert/dto/response/UnReadAlertResponseDto.kt
@@ -1,0 +1,13 @@
+package com.umcspot.spot.alert.dto.response
+
+import android.annotation.SuppressLint
+import com.umcspot.spot.model.ImageRef
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@SuppressLint("UnsafeOptInUsageError")
+@Serializable
+data class UnReadAlertResponseDto(
+    @SerialName("hasUnreadNotifications")
+    val hasUnreadNotifications : Boolean
+)

--- a/data/alert/src/main/java/com/umcspot/spot/alert/mapper/AlertMapper.kt
+++ b/data/alert/src/main/java/com/umcspot/spot/alert/mapper/AlertMapper.kt
@@ -2,19 +2,30 @@ package com.umcspot.spot.alert.mapper
 
 import com.umcspot.spot.alert.dto.response.AlertItem
 import com.umcspot.spot.alert.dto.response.AlertResponseDto
+import com.umcspot.spot.alert.dto.response.UnReadAlertResponseDto
 import com.umcspot.spot.alert.model.AlertInfo
 import com.umcspot.spot.alert.model.AlertResult
+import com.umcspot.spot.model.formatCreatedAt
+import com.umcspot.spot.model.toImageRef
 
 
 fun AlertItem.toDomain() : AlertInfo =
     AlertInfo (
-        applicationId = this.applicationId.toLong(),
-        studyId = this.studyId.toLong(),
+        notificationId = this.notificationId.toLong(),
+        type = this.type,
         title = this.title,
-        studyImageRes = this.profileImageRef,
+        body = this.body,
+        imageUrl = this.imageUrl.toImageRef(),
+        referenceType = this.referenceType,
+        referenceId = this.referenceId.toLong(),
+        isRead = this.isRead,
+        createdAt = this.createdAt.formatCreatedAt()
     )
 
 fun AlertResponseDto.toDomainList(): AlertResult =
     AlertResult(
-        studies = this.studies.map(AlertItem::toDomain)
+        notifications = this.notifications.map(AlertItem::toDomain),
+        totalCount = this.totalCount
     )
+
+fun UnReadAlertResponseDto.toDomain() : Boolean = this.hasUnreadNotifications

--- a/data/alert/src/main/java/com/umcspot/spot/alert/repositoryimpl/AlertRepositoryImpl.kt
+++ b/data/alert/src/main/java/com/umcspot/spot/alert/repositoryimpl/AlertRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.umcspot.spot.alert.repositoryimpl
 
 import android.util.Log
 import com.umcspot.spot.alert.datasource.AlertDataSource
+import com.umcspot.spot.alert.mapper.toDomain
 import com.umcspot.spot.alert.mapper.toDomainList
 import com.umcspot.spot.alert.model.AlertResult
 import com.umcspot.spot.alert.repository.AlertRepository
@@ -16,6 +17,19 @@ class AlertRepositoryImpl @Inject constructor(
             response.result.toDomainList()
         }.onFailure { e ->
             Log.e("AlertRepositoryImpl", "getAlerts error", e)
+        }
+
+    override suspend fun getUnReadAlerts(): Result<Boolean> =
+        runCatching {
+            val response = alertDataSource.getUnReadAlerts()
+            response.result.toDomain()
+        }.onFailure { e ->
+            Log.e("AlertRepositoryImpl", "getUnReadAlerts error", e)
+        }
+
+    override suspend fun readAlert(notificationId: Long): Result<Unit> =
+        runCatching {
+            alertDataSource.readAlert(notificationId)
         }
 
 }

--- a/data/alert/src/main/java/com/umcspot/spot/alert/service/AlertService.kt
+++ b/data/alert/src/main/java/com/umcspot/spot/alert/service/AlertService.kt
@@ -1,11 +1,23 @@
 package com.umcspot.spot.alert.service
 
 import com.umcspot.spot.alert.dto.response.AlertResponseDto
+import com.umcspot.spot.alert.dto.response.UnReadAlertResponseDto
 import com.umcspot.spot.network.model.BaseResponse
+import com.umcspot.spot.network.model.NullResultResponse
 import retrofit2.http.GET
+import retrofit2.http.Path
 
 interface AlertService {
-    @GET("/api/studies/applied")
+    @GET("/api/notifications/me")
     suspend fun getAlerts(
     ): BaseResponse<AlertResponseDto>
+
+    @GET("/api/notifications/me/unread")
+    suspend fun getUnReadAlerts(
+    ): BaseResponse<UnReadAlertResponseDto>
+
+    @GET("/api/notifications/{notificationId}/read")
+    suspend fun readAlert(
+        @Path("notificationId") notificationId: Long,
+    ): NullResultResponse
 }

--- a/data/login/src/main/java/com/umcspot/spot/login/dto/response/TokenResponseDto.kt
+++ b/data/login/src/main/java/com/umcspot/spot/login/dto/response/TokenResponseDto.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class TokenResponseDto(
+    @SerialName("id")
+    val userId: String,
     @SerialName("accessToken")
     val accessToken: String,
     @SerialName("refreshToken")

--- a/data/login/src/main/java/com/umcspot/spot/login/mapper/TokenMapper.kt
+++ b/data/login/src/main/java/com/umcspot/spot/login/mapper/TokenMapper.kt
@@ -12,6 +12,7 @@ fun TokenType.toDto() : TokenRequestDto =
 
 fun TokenResponseDto.toDomain() : TokenResult =
     TokenResult (
+        userId = this.userId,
         accessToken = this.accessToken,
         refreshToken = this.refreshToken
     )

--- a/data/login/src/main/java/com/umcspot/spot/login/repositoryimpl/LoginRepositoryImpl.kt
+++ b/data/login/src/main/java/com/umcspot/spot/login/repositoryimpl/LoginRepositoryImpl.kt
@@ -1,7 +1,8 @@
 package com.umcspot.spot.login.repositoryimpl
 
 import androidx.datastore.core.DataStore
-import com.umcspot.spot.datastore.SpotTokenData
+import com.umcspot.spot.datastore.token.SpotTokenData
+import com.umcspot.spot.datastore.userId.SpotUserIdData
 import com.umcspot.spot.login.mapper.toDomain
 import com.umcspot.spot.login.service.LoginService
 import com.umcspot.spot.model.SocialLoginType
@@ -11,7 +12,8 @@ import javax.inject.Inject
 
 class LoginRepositoryImpl @Inject constructor(
     private val studyService: LoginService,
-    private val spotTokenDataStore: DataStore<SpotTokenData>
+    private val spotTokenDataStore: DataStore<SpotTokenData>,
+    private val spotUserIdDataStore: DataStore<SpotUserIdData>
 ) : TokenRepository {
 
     override suspend fun finishSocialLogin(
@@ -26,6 +28,12 @@ class LoginRepositoryImpl @Inject constructor(
                 current.copy(
                     accessToken = tokenResult.accessToken,
                     refreshToken = tokenResult.refreshToken
+                )
+            }
+
+            spotUserIdDataStore.updateData { current ->
+                current.copy(
+                    userId = tokenResult.userId
                 )
             }
 

--- a/domain/alert/src/main/java/com/umcspot/spot/alert/model/AlertResult.kt
+++ b/domain/alert/src/main/java/com/umcspot/spot/alert/model/AlertResult.kt
@@ -4,12 +4,18 @@ import com.umcspot.spot.model.ImageRef
 
 /******** 일반 알람 ********/
 data class AlertResult (
-    val studies : List<AlertInfo>
+    val notifications : List<AlertInfo>,
+    val totalCount : Int
 )
 
 data class AlertInfo(
-    val applicationId: Long,
-    val studyId: Long,
+    val notificationId: Long,
+    val type: String,
     val title: String,
-    val studyImageRes: ImageRef,
+    val body: String,
+    val imageUrl: ImageRef,
+    val referenceType: String,
+    val referenceId: Long,
+    val isRead: Boolean,
+    val createdAt: String,
 )

--- a/domain/alert/src/main/java/com/umcspot/spot/alert/repository/AlertRepository.kt
+++ b/domain/alert/src/main/java/com/umcspot/spot/alert/repository/AlertRepository.kt
@@ -4,4 +4,8 @@ import com.umcspot.spot.alert.model.AlertResult
 
 interface AlertRepository {
     suspend fun getAlerts(): Result<AlertResult>
+
+    suspend fun getUnReadAlerts(): Result<Boolean>
+
+    suspend fun readAlert(notificationId: Long): Result<Unit>
 }

--- a/domain/token/src/main/java/com/umcspot/spot/token/model/TokenResult.kt
+++ b/domain/token/src/main/java/com/umcspot/spot/token/model/TokenResult.kt
@@ -1,6 +1,7 @@
 package com.umcspot.spot.token.model
 
 data class TokenResult (
+    val userId : String,
     val accessToken : String,
-    val refreshToken : String
+    val refreshToken : String,
 )

--- a/feature/alert/src/main/java/com/umcspot/spot/alert/AlertScreen.kt
+++ b/feature/alert/src/main/java/com/umcspot/spot/alert/AlertScreen.kt
@@ -1,20 +1,32 @@
 package com.umcspot.spot.alert
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.umcspot.spot.alert.model.AlertInfo
@@ -23,11 +35,9 @@ import com.umcspot.spot.designsystem.R
 import com.umcspot.spot.designsystem.component.SpotSpinner
 import com.umcspot.spot.designsystem.component.button.BlankButton
 import com.umcspot.spot.designsystem.component.empty.EmptyAlert
-import com.umcspot.spot.designsystem.shapes.ShapeBox
 import com.umcspot.spot.designsystem.shapes.ShapeImageBox
+import com.umcspot.spot.designsystem.shapes.ShapeImageWithBadge
 import com.umcspot.spot.designsystem.shapes.SpotShapes
-import com.umcspot.spot.designsystem.theme.B400
-import com.umcspot.spot.designsystem.theme.Black
 import com.umcspot.spot.designsystem.theme.G300
 import com.umcspot.spot.designsystem.theme.SpotTheme
 import com.umcspot.spot.ui.extension.screenHeightDp
@@ -70,7 +80,12 @@ fun AlertScreen(
                 AlertScreenContent(
                     state = alertsState.data,
                     listState = listState,
-                    onClickAlert = onClickAlert
+                    onClickAlert = {
+                        if(it.referenceType == "STUDY") {
+                            viewModel.readAlert(it.notificationId)
+                            onClickAlert(it.referenceId)
+                        }
+                    }
                 )
             }
 
@@ -104,9 +119,9 @@ fun AlertScreen(
 fun AlertScreenContent(
     state: AlertResult,
     listState: LazyListState,
-    onClickAlert: (Long) -> Unit,
+    onClickAlert: (AlertInfo) -> Unit,
 ) {
-    val alerts: List<AlertInfo> = state.studies
+    val alerts: List<AlertInfo> = state.notifications
 
     LazyColumn(
         state = listState,
@@ -114,7 +129,7 @@ fun AlertScreenContent(
     ) {
         items(
             items = alerts,
-            key = { it.applicationId }
+            key = { it.notificationId }
         ) { item ->
             Spacer(modifier = Modifier.height(screenHeightDp(4.dp)))
 
@@ -125,9 +140,9 @@ fun AlertScreenContent(
             HorizontalDivider(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = screenWidthDp(17.dp)),
+                    .padding(horizontal = screenWidthDp(10.dp)),
                 color = SpotTheme.colors.G300,
-                thickness = 1.dp
+                thickness = 0.5.dp
             )
         }
 
@@ -139,22 +154,24 @@ fun AlertScreenContent(
 @Composable
 fun AlertRow(
     data: AlertInfo,
-    onClick: (Long) -> Unit
+    onClick: (AlertInfo) -> Unit
 ) {
     BlankButton(
         modifier = Modifier
             .width(screenWidthDp(326.dp))
             .height(screenHeightDp(65.dp)),
-        onClick = { onClick(data.studyId) },
+        onClick = { onClick(data) },
+        shape = SpotShapes.Hard
     ) {
         Row(
             modifier = Modifier.padding(screenWidthDp(13.dp)),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            ShapeImageBox(
-                imageRef = data.studyImageRes,
+            ShapeImageWithBadge(
+                imageRef = data.imageUrl,
                 shape = SpotShapes.Soft,
-                modifier = Modifier.size(screenWidthDp(33.dp)),
+                modifier = Modifier.size(screenWidthDp(36.dp)),
+                badgeSize = 10.dp,
                 backgroundColor = SpotTheme.colors.white,
             )
 
@@ -168,7 +185,7 @@ fun AlertRow(
                     overflow = TextOverflow.Ellipsis
                 )
                 Text(
-                    text = "게시판에서 가입 인사를 나눠보세요!",
+                    text = data.body,
                     style = SpotTheme.typography.regular_400,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis

--- a/feature/alert/src/main/java/com/umcspot/spot/alert/AlertViewmodel.kt
+++ b/feature/alert/src/main/java/com/umcspot/spot/alert/AlertViewmodel.kt
@@ -34,13 +34,24 @@ class AlertViewModel @Inject constructor(
             alertRepository.getAlerts()
                 .onSuccess { result: AlertResult ->
                     val newState: UiState<AlertResult> =
-                        if (result.studies.isEmpty()) UiState.Empty else UiState.Success(result)
+                        if (result.notifications.isEmpty()) UiState.Empty else UiState.Success(result)
 
                     _uiState.update { state -> state.copy(alerts = newState) }
                 }
                 .onFailure { e ->
                     Log.e("AlertViewModel", "loadAlert error", e)
 //                  _uiState.update { state -> state.copy(alerts = UiState.Failure(e.message ?: e.toString())) }
+                }
+        }
+    }
+
+    fun readAlert(notificationId: Long) {
+        viewModelScope.launch {
+            alertRepository.readAlert(notificationId)
+                .onSuccess {
+                    load()
+                }.onFailure {
+                    Log.e("AlertViewModel", "readAlert error", it)
                 }
         }
     }

--- a/feature/home/src/main/java/com/umcspot/spot/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/umcspot/spot/home/HomeScreen.kt
@@ -376,8 +376,7 @@ fun HomeScreenContent(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = screenWidthDp(17.dp))
-            .padding(top = screenHeightDp(18.dp), bottom = screenHeightDp(24.dp)),
+            .padding(horizontal = screenWidthDp(17.dp)),
         state = listState
     ) {
         item {

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(projects.feature.board)
     implementation(projects.feature.alert)
 
+    implementation(projects.domain.alert)
     implementation(projects.core.model)
 
     implementation(libs.androidx.splashscreen)

--- a/feature/main/src/main/java/com/umcspot/spot/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/umcspot/spot/main/MainScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -19,6 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.umcspot.spot.alert.navigation.Alert
@@ -55,6 +58,7 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 fun MainScreen(
     navigator: MainNavigator = rememberMainNavigator(),
+    mainViewModel: MainViewModel = hiltViewModel()
 ) {
     val navController = navigator.navController
     val backStackEntry by navController.currentBackStackEntryAsState()
@@ -62,6 +66,14 @@ fun MainScreen(
     var scrollToTop by remember { mutableStateOf<(() -> Unit)?>(null) }
 
     var showBackRequestDialog by remember { mutableStateOf(false) }
+
+    val hasUnreadAlert by mainViewModel.hasUnreadAlert.collectAsStateWithLifecycle()
+
+    val isHome = dest?.hasRoute(Home::class) == true
+
+    LaunchedEffect(isHome) {
+        if (isHome) mainViewModel.loadUnreadAlerts()
+    }
 
     Scaffold(
         topBar = {
@@ -104,7 +116,7 @@ fun MainScreen(
                     )
                 } else {
                     AppBarHome(
-                        hasAlert = true,
+                        hasAlert = hasUnreadAlert,
                         onSearchClick = { /* TODO */ },
                         onAlertClick = { navController.navigateToAlert() },
                         modifier = Modifier

--- a/feature/main/src/main/java/com/umcspot/spot/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/umcspot/spot/main/MainViewModel.kt
@@ -1,0 +1,32 @@
+package com.umcspot.spot.main
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.umcspot.spot.alert.repository.AlertRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val alertRepository: AlertRepository
+) : ViewModel() {
+
+    private val _hasUnreadAlert = MutableStateFlow(false)
+    val hasUnreadAlert: StateFlow<Boolean> = _hasUnreadAlert
+
+    private var loading = false
+
+    fun loadUnreadAlerts() {
+        if (loading) return
+        loading = true
+
+        viewModelScope.launch {
+            alertRepository.getUnReadAlerts()
+                .onSuccess { _hasUnreadAlert.value = it }
+            loading = false
+        }
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- 

## Work Description 📝
- dataStore에 UserId 추가
- alertScreen API 연동 및 로직 추가

## Screenshot 📸
<img width="350" height="800" alt="image" src="https://github.com/user-attachments/assets/93c1d7a5-212d-42b8-af52-79ef941e8066" />

## Uncompleted Tasks 😅
-

## PR Point 📌

## 트러블 슈팅 💥

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알림 미확인 여부 조회 기능 추가
  * 개별 알림을 읽음으로 표시하는 기능 추가
  * 로그인 시 사용자 ID를 안전하게 저장하는 기능 추가

* **UI**
  * 알림 항목 레이아웃·이미지·패딩·구분선 등 시각 개선
  * 알림 클릭 시 전체 항목 데이터 전달로 동작 개선
  * 홈 화면에 미확인 알림 배지 표시

* **Refactor**
  * 알림 데이터 구조 확장(유형·본문·이미지·참조·생성시각·읽음 상태 등)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->